### PR TITLE
Terraform deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ gin-bin
 *.log
 *.etcd
 **/node_modules/**
+**.idea
+**.terraform
+**.tfstate*

--- a/dist/manifests/config-api/embed-config-api-svc.yaml
+++ b/dist/manifests/config-api/embed-config-api-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: embed-config-api
+  labels:
+    app: embed-config-api
+spec:
+  type: LoadBalancer
+  ports:
+  - name: embed-config
+    targetPort: 8888
+    port: 80
+  selector:
+    app: embed-config-api

--- a/dist/manifests/config-api/embed-config-api.yaml
+++ b/dist/manifests/config-api/embed-config-api.yaml
@@ -1,0 +1,59 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    heritage: huv
+    app: embed-config-api
+  name: embed-config-api
+spec:
+  selector:
+    matchLabels:
+      app: embed-config-api
+  template:
+    metadata:
+      labels:
+        app: embed-config-api
+      name: embed-config-api
+    spec:
+      containers:
+        - name: config-api
+          image: usermirror/config-api:latest
+          env:
+            - name: CONFIG_API_STORAGE_BACKEND
+              value: postgres
+            - name: CONFIG_API_POSTGRES_ADDR
+              value: postgres://huv_user:changeme@localhost:3306/huv-db?sslmode=disable
+          ports:
+            - name: embed-config
+              containerPort: 8888
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /internal/health
+              port: 8888
+          readinessProbe:
+            httpGet:
+              path: /internal/health
+              port: 8888
+        - name: cloudsql-proxy
+          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          command: ["/cloud_sql_proxy",
+                    "-instances=$(INSTANCE_CONNECTION_NAME)=tcp:3306",
+                    "-credential_file=/secrets/cloudsql/service-account-key"]
+          env:
+          - name: INSTANCE_CONNECTION_NAME
+            valueFrom:
+              secretKeyRef:
+                name: sql-access
+                key: instance-connection-name
+          securityContext:
+            runAsUser: 2  # non-root user
+            allowPrivilegeEscalation: false
+          volumeMounts:
+          - name: sql-access-credentials
+            mountPath: /secrets/cloudsql
+            readOnly: true
+      volumes:
+      - name: sql-access-credentials
+        secret:
+          secretName: sql-access

--- a/manifests/config-api/embed-config-api-svc.yaml
+++ b/manifests/config-api/embed-config-api-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: embed-config-api
+  labels:
+    app: embed-config-api
+spec:
+  type: LoadBalancer
+  ports:
+  - name: embed-config
+    targetPort: 8888
+    port: 80
+  selector:
+    app: embed-config-api

--- a/manifests/config-api/embed-config-api.yaml
+++ b/manifests/config-api/embed-config-api.yaml
@@ -1,0 +1,59 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    heritage: huv
+    app: embed-config-api
+  name: embed-config-api
+spec:
+  selector:
+    matchLabels:
+      app: embed-config-api
+  template:
+    metadata:
+      labels:
+        app: embed-config-api
+      name: embed-config-api
+    spec:
+      containers:
+        - name: config-api
+          image: usermirror/config-api:latest
+          env:
+            - name: CONFIG_API_STORAGE_BACKEND
+              value: postgres
+            - name: CONFIG_API_POSTGRES_ADDR
+              value: postgres://huv_user:${sql_db_password}@localhost:3306/huv-db?sslmode=disable
+          ports:
+            - name: embed-config
+              containerPort: 8888
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /internal/health
+              port: 8888
+          readinessProbe:
+            httpGet:
+              path: /internal/health
+              port: 8888
+        - name: cloudsql-proxy
+          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          command: ["/cloud_sql_proxy",
+                    "-instances=$(INSTANCE_CONNECTION_NAME)=tcp:3306",
+                    "-credential_file=/secrets/cloudsql/service-account-key"]
+          env:
+          - name: INSTANCE_CONNECTION_NAME
+            valueFrom:
+              secretKeyRef:
+                name: sql-access
+                key: instance-connection-name
+          securityContext:
+            runAsUser: 2  # non-root user
+            allowPrivilegeEscalation: false
+          volumeMounts:
+          - name: sql-access-credentials
+            mountPath: /secrets/cloudsql
+            readOnly: true
+      volumes:
+      - name: sql-access-credentials
+        secret:
+          secretName: sql-access

--- a/manifests/config.yaml
+++ b/manifests/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deploy-config
+data:
+  config-api: |
+    sql_db_password: "changeme"

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,0 +1,44 @@
+provider "google" {
+  version = "~> 1.17"
+
+  credentials = "${var.gcloud_creds}"
+  project     = "${var.cluster_project}"
+  region      = "${var.cluster_zone}"
+}
+
+// defaults requiring interpolation
+locals {
+  render_dir    = "${var.render_dir=="" ? local.default_render_dir : var.render_dir}"
+  config_path   = "${var.config_path=="" ? local.default_config_path : var.config_path}"
+  manifests_dir = "${var.manifests_dir=="" ? local.default_manifests_dir : var.manifests_dir}"
+
+  default_render_dir    = "${dirname(dirname(path.module))}/dist/manifests"
+  default_config_path   = "${dirname(dirname(path.module))}/manifests/config.yaml"
+  default_manifests_dir = "${dirname(dirname(path.module))}/manifests"
+}
+
+module "config-api" {
+  source = "../"
+
+  kubeconfig    = "${var.kubeconfig}"
+  config_path   = "${local.config_path}"
+  manifests_dir = "${local.manifests_dir}"
+  render_dir    = "${local.render_dir}"
+
+  last_resource = "${module.cloudsql_db.sql_access_key}"
+}
+
+// cloudsql_db creates a user, database, and access credentials on a PostgreSQL instance.
+module "cloudsql_db" {
+  source = "git::https://github.com/helpusersvote/terraform-kubernetes-helpusersvote.git//modules/cloudsql_db"
+
+  render_dir = "${local.manifests_dir}/config-api"
+
+  client_service_account_email = "${var.sql_service_account_email}"
+  connection_name              = "${var.sql_connection_name}"
+  instance                     = "${var.sql_instance_id}"
+
+  db_user          = "huv_user"
+  db_user_password = "${var.sql_db_password}"
+  db_name          = "huv_db"
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -1,0 +1,60 @@
+variable "render_dir" {
+  description = "Path to output generated Kubernetes manifests"
+  type        = "string"
+  default     = ""
+}
+
+variable "config_path" {
+  description = "Path to ConfigMap describing configuration for config-api"
+  type        = "string"
+  default     = ""
+}
+
+variable "manifests_dir" {
+  description = "Directory containing manifests used for deployment"
+  type        = "string"
+  default     = ""
+}
+
+variable "kubeconfig" {
+  description = "Path to kubeconfig used to authenticate with Kubernetes API server"
+  type        = "string"
+}
+
+variable "gcloud_creds" {
+  description = "Credentials used to authenticate with Google Cloud and create a cluster. Credentials can be downloaded at https://console.cloud.google.com/apis/credentials/serviceaccountkey."
+  type        = "string"
+  default     = ""
+}
+
+variable "cluster_project" {
+  description = "Gcloud project to deploy cluster in."
+  type        = "string"
+}
+
+variable "cluster_zone" {
+  description = "Gcloud zone to deploy in."
+  type        = "string"
+  default     = "us-west1"
+}
+
+variable "sql_service_account_email" {
+  description = "Email of the Google Service Account used to access SQL database instances."
+  type        = "string"
+}
+
+variable "sql_connection_name" {
+  description = "Hostname provided by Google to connect to a Cloud SQL instance"
+  type        = "string"
+}
+
+variable "sql_instance_id" {
+  description = "ID of the Cloud SQL instance"
+  type        = "string"
+}
+
+variable "sql_db_password" {
+  description = "Password for the SQL user used to perform writes."
+  type        = "string"
+  default     = "changeme"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,23 @@
+// defaults requiring interpolation
+locals {
+  render_dir    = "${var.render_dir=="" ? local.default_render_dir : var.render_dir}"
+  config_path   = "${var.config_path=="" ? local.default_config_path : var.config_path}"
+  manifests_dir = "${var.manifests_dir=="" ? local.default_manifests_dir : var.manifests_dir}"
+
+  default_render_dir    = "${dirname(path.module)}/dist/manifests"
+  default_config_path   = "${dirname(path.module)}/manifests/config.yaml"
+  default_manifests_dir = "${dirname(path.module)}/manifests"
+
+  last = "${element(list("", var.last_resource), 0)}"
+}
+
 module "config" {
   source = "git::https://github.com/helpusersvote/terraform-kubernetes-helpusersvote.git//modules/config"
 
   components   = ["config-api"]
-  config       = "${var.config_path}"
-  manifest_dir = "${var.manifests_dir}"
-  render_dir   = "${var.render_dir}"
+  render_dir   = "${local.render_dir}"
+  config       = "${local.config_path}${local.last}" // TODO: remove once module dependency can be improved
+  manifest_dir = "${local.manifests_dir}"
 }
 
 module "kubernetes" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,16 @@
+module "config" {
+  source = "git::https://github.com/helpusersvote/terraform-kubernetes-helpusersvote.git//modules/config"
+
+  components   = ["config-api"]
+  config       = "${var.config_path}"
+  manifest_dir = "${var.manifests_dir}"
+  render_dir   = "${var.render_dir}"
+}
+
+module "kubernetes" {
+  source = "git::https://github.com/helpusersvote/terraform-kubernetes-helpusersvote.git//modules/kubernetes"
+
+  manifest_dirs = "${module.config.dirs}"
+  kubeconfig    = "${var.kubeconfig}"
+  last_resource = "${join(",", module.config.manifest_state)}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,22 @@
+variable "render_dir" {
+  description = "Path to directory where templated manifests can be outputted"
+  type        = "string"
+  default     = "../dist/manifests"
+}
+
+variable "config_path" {
+  description = "Path to ConfigMap describing configuration for config-api"
+  type        = "string"
+  default     = "../manifests/config.yaml"
+}
+
+variable "manifests_dir" {
+  description = "Directory containing manifests used for deployment"
+  type        = "string"
+  default     = "../manifests"
+}
+
+variable "kubeconfig" {
+  description = "Path to kubeconfig used to authenticate with Kubernetes API server"
+  type        = "string"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,22 +1,28 @@
 variable "render_dir" {
-  description = "Path to directory where templated manifests can be outputted"
+  description = "Path to directory where templated manifests can be outputted (defaults to path within module)"
   type        = "string"
-  default     = "../dist/manifests"
+  default     = ""
 }
 
 variable "config_path" {
-  description = "Path to ConfigMap describing configuration for config-api"
+  description = "Path to ConfigMap describing configuration for config-api (defaults to path within module)"
   type        = "string"
-  default     = "../manifests/config.yaml"
+  default     = ""
 }
 
 variable "manifests_dir" {
-  description = "Directory containing manifests used for deployment"
+  description = "Directory containing manifests used for deployment (defaults to path within module)"
   type        = "string"
-  default     = "../manifests"
+  default     = ""
 }
 
 variable "kubeconfig" {
   description = "Path to kubeconfig used to authenticate with Kubernetes API server"
   type        = "string"
+}
+
+variable "last_resource" {
+  description = "Allows dependency to be expressed to module"
+  type        = "string"
+  default     = ""
 }


### PR DESCRIPTION
- Renders Kubernetes manifests from templates using `config` module
- Committed manifests created from those templates
- Uses `kubernetes` module to deploy into an existing cluster

# To-Do
- [x] Setup Google Cloud SQL Database provider specific Terraform directory
- [x] Allow [terraform-kubernetes-helpusersvote](https://github.com/helpusersvote/terraform-kubernetes-helpusersvote) to use module to deploy
- [ ] Setup check that generated manifests were committed (pre-commit and during CI)
- [ ] Run deployment as part of CI into existing environment